### PR TITLE
Wip] maker logo from spiffs

### DIFF
--- a/src/OXRS_LCD.cpp
+++ b/src/OXRS_LCD.cpp
@@ -3,6 +3,14 @@
 #include "OXRS_LCD.h"
 #include <ArduinoJson.h>
 
+// Call up the SPIFFS FLASH filing system this is part of the ESP Core
+#define FS_NO_GLOBALS
+
+#ifdef ESP32
+  #include "SPIFFS.h"  // For ESP32 only
+#endif
+
+
 // makers taken from https://oxrs.io/glossary/makers.html
 PROGMEM const char maker_table[] = {
                             "[{\"code\":\"AC\",\"name\":\"Austin's Creations\"},"
@@ -54,6 +62,13 @@ void OXRS_LCD::begin (uint32_t ontime_event, uint32_t ontime_display)
   
   _ontime_display = ontime_display;
   _ontime_event = ontime_event;
+  
+
+  if (!SPIFFS.begin()) {
+    Serial.println("SPIFFS initialisation failed!");
+    while (1) yield(); // Stay here twiddling thumbs waiting
+  }
+  Serial.println("\r\nSPIFFS initialised."); 
 }
 
 
@@ -107,7 +122,9 @@ void OXRS_LCD::draw_header(const char * fw_maker_code, const char * fw_name, con
     logo_bg = TFT_BLUE;
   }
  
-  tft.drawBitmap(0, 0, logo_bm, logo_w, logo_h, logo_fg, logo_bg);
+//  tft.drawBitmap(0, 0, logo_bm, logo_w, logo_h, logo_fg, logo_bg);
+  _drawBmp("/logo.bmp", 0, 0);
+
   tft.fillRect(42, 0, 240, 40,  TFT_WHITE);
   tft.setTextDatum(TL_DATUM);
   tft.setTextColor(TFT_BLACK);
@@ -732,4 +749,97 @@ void OXRS_LCD::_set_ip_link_led(int active)
 void OXRS_LCD::_set_backlight(int val)
 {
   ledcWrite(BL_PWM_CHANNEL, 255*val/100); 
+}
+
+
+
+
+// Bodmers BMP image rendering function
+
+void OXRS_LCD::_drawBmp(const char *filename, int16_t x, int16_t y) {
+
+  if ((x >= tft.width()) || (y >= tft.height())) return;
+
+  fs::File bmpFS;
+
+  // Open requested file on SD card
+  bmpFS = SPIFFS.open(filename, "r");
+
+  if (!bmpFS)
+  {
+    Serial.print("File not found");
+    return;
+  }
+
+  uint32_t seekOffset;
+  uint16_t w, h, row, col;
+  uint8_t  r, g, b;
+
+  uint32_t startTime = millis();
+
+  if (_read16(bmpFS) == 0x4D42)
+  {
+    _read32(bmpFS);
+    _read32(bmpFS);
+    seekOffset = _read32(bmpFS);
+    _read32(bmpFS);
+    w = _read32(bmpFS);
+    h = _read32(bmpFS);
+
+    if ((_read16(bmpFS) == 1) && (_read16(bmpFS) == 24) && (_read32(bmpFS) == 0))
+    {
+      y += h - 1;
+
+      bool oldSwapBytes = tft.getSwapBytes();
+      tft.setSwapBytes(true);
+      bmpFS.seek(seekOffset);
+
+      uint16_t padding = (4 - ((w * 3) & 3)) & 3;
+      uint8_t lineBuffer[w * 3 + padding];
+
+      for (row = 0; row < h; row++) {
+        
+        bmpFS.read(lineBuffer, sizeof(lineBuffer));
+        uint8_t*  bptr = lineBuffer;
+        uint16_t* tptr = (uint16_t*)lineBuffer;
+        // Convert 24 to 16 bit colours
+        for (uint16_t col = 0; col < w; col++)
+        {
+          b = *bptr++;
+          g = *bptr++;
+          r = *bptr++;
+          *tptr++ = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
+        }
+
+        // Push the pixel row to screen, pushImage will crop the line if needed
+        // y is decremented as the BMP image is drawn bottom up
+        tft.pushImage(x, y--, w, 1, (uint16_t*)lineBuffer);
+      }
+      tft.setSwapBytes(oldSwapBytes);
+      Serial.print("Loaded in "); Serial.print(millis() - startTime);
+      Serial.println(" ms");
+    }
+    else Serial.println("BMP format not recognized.");
+  }
+  bmpFS.close();
+}
+
+// These read 16- and 32-bit types from the SD card file.
+// BMP data is stored little-endian, Arduino is little-endian too.
+// May need to reverse subscript order if porting elsewhere.
+
+uint16_t OXRS_LCD::_read16(fs::File &f) {
+  uint16_t result;
+  ((uint8_t *)&result)[0] = f.read(); // LSB
+  ((uint8_t *)&result)[1] = f.read(); // MSB
+  return result;
+}
+
+uint32_t OXRS_LCD::_read32(fs::File &f) {
+  uint32_t result;
+  ((uint8_t *)&result)[0] = f.read(); // LSB
+  ((uint8_t *)&result)[1] = f.read();
+  ((uint8_t *)&result)[2] = f.read();
+  ((uint8_t *)&result)[3] = f.read(); // MSB
+  return result;
 }

--- a/src/OXRS_LCD.cpp
+++ b/src/OXRS_LCD.cpp
@@ -3,12 +3,7 @@
 #include "OXRS_LCD.h"
 #include <ArduinoJson.h>
 
-// Call up the SPIFFS FLASH filing system this is part of the ESP Core
-#define FS_NO_GLOBALS
 
-#ifdef ESP32
-  #include "SPIFFS.h"  // For ESP32 only
-#endif
 
 
 // makers taken from https://oxrs.io/glossary/makers.html
@@ -63,7 +58,8 @@ void OXRS_LCD::begin (uint32_t ontime_event, uint32_t ontime_display)
   _ontime_display = ontime_display;
   _ontime_event = ontime_event;
   
-
+  // rethink the following
+  // after SPIFFS is enabled during startup already
   if (!SPIFFS.begin()) {
     Serial.println("SPIFFS initialisation failed!");
     while (1) yield(); // Stay here twiddling thumbs waiting
@@ -122,7 +118,6 @@ void OXRS_LCD::draw_header(const char * fw_maker_code, const char * fw_name, con
     logo_bg = TFT_BLUE;
   }
  
-//  tft.drawBitmap(0, 0, logo_bm, logo_w, logo_h, logo_fg, logo_bg);
   _drawBmp("/logo.bmp", 0, 0);
 
   tft.fillRect(42, 0, 240, 40,  TFT_WHITE);
@@ -164,8 +159,8 @@ void OXRS_LCD::show_MQTT_topic (char * topic)
   sprintf(buffer, "MQTT: %s",topic);
   tft.drawString(buffer, 12, 80);
 
-  _set_mqtt_rx_led(0);
-  _set_mqtt_tx_led(0); 
+  _set_mqtt_rx_led(2);
+  _set_mqtt_tx_led(2); 
 }
 
 
@@ -295,6 +290,14 @@ void OXRS_LCD::trigger_mqtt_tx_led (void)
   _last_tx_trigger = millis(); 
 }
 
+void OXRS_LCD::show_mqtt_not_connected (void)
+{
+  _set_mqtt_tx_led(2);
+  _set_mqtt_rx_led(2);
+  _last_tx_trigger = 0L;
+  _last_rx_trigger = 0L;
+}
+
 /*
  * process io_value :
  * check for changes vs last stored value
@@ -408,6 +411,7 @@ void OXRS_LCD::_show_ethernet()
     // refresh IP on link status change
     if (_ethernet_link_status == LinkON)
     {
+      if (_ethernet->localIP()[0] == 0) {_ethernet_link_status = Unknown;}
       _show_IP(_ethernet->localIP(), 1);
     }
     else
@@ -456,7 +460,14 @@ void OXRS_LCD::_show_IP (IPAddress ip, int link_status)
   tft.setTextColor(TFT_WHITE);
   tft.setTextDatum(TL_DATUM);
   tft.setFreeFont(&Roboto_Mono_Thin_13);
-  sprintf(buffer, "IP  : %03d.%03d.%03d.%03d", ip[0],ip[1], ip[2], ip[3]);
+  if (ip[0] == 0)
+  {
+    sprintf(buffer, "IP  : ---.---.---.---");
+  }
+  else
+  {
+    sprintf(buffer, "IP  : %03d.%03d.%03d.%03d", ip[0],ip[1], ip[2], ip[3]);
+  }
   tft.drawString(buffer, 12, 50);
 
   _set_ip_link_led(link_status);
@@ -719,20 +730,18 @@ void OXRS_LCD::_update_io_48 (uint8_t type, uint8_t index, int active)
 /*
  * animated "leds"
  */
-void OXRS_LCD::_set_mqtt_rx_led(int active)
+void OXRS_LCD::_set_mqtt_rx_led(int state)
 {
-  uint16_t color;
- 
-  color = active ? TFT_YELLOW : TFT_DARKGREY;
-  tft.fillRoundRect(2, 80, 8, 5, 2,  color);
+  uint16_t color[3] = {TFT_DARKGREY, TFT_YELLOW, TFT_RED};
+  
+  if (state < 3) tft.fillRoundRect(2, 80, 8, 5, 2,  color[state]);
 }
 
-void OXRS_LCD::_set_mqtt_tx_led(int active)
+void OXRS_LCD::_set_mqtt_tx_led(int state)
 {
-  uint16_t color;
- 
-  color = active ? TFT_ORANGE : TFT_DARKGREY;
-  tft.fillRoundRect(2, 88, 8, 5, 2,  color);
+   uint16_t color[3] = {TFT_DARKGREY, TFT_ORANGE, TFT_RED};
+
+  if (state < 3) tft.fillRoundRect(2, 88, 8, 5, 2,  color[state]);
 }
 
 void OXRS_LCD::_set_ip_link_led(int active)
@@ -756,26 +765,20 @@ void OXRS_LCD::_set_backlight(int val)
 
 // Bodmers BMP image rendering function
 
-void OXRS_LCD::_drawBmp(const char *filename, int16_t x, int16_t y) {
-
-  if ((x >= tft.width()) || (y >= tft.height())) return;
-
-  fs::File bmpFS;
-
-  // Open requested file on SD card
-  bmpFS = SPIFFS.open(filename, "r");
-
-  if (!bmpFS)
-  {
-    Serial.print("File not found");
-    return;
-  }
-
+void OXRS_LCD::_drawBmp(const char *filename, int16_t x, int16_t y) 
+{
   uint32_t seekOffset;
   uint16_t w, h, row, col;
   uint8_t  r, g, b;
+  File bmpFS;
 
-  uint32_t startTime = millis();
+  // Open requested file on SPIFFS
+  bmpFS = SPIFFS.open(filename, "r");
+  if (!bmpFS)
+  {
+    Serial.println(F("[lcd] File not found"));
+    return;
+  }
 
   if (_read16(bmpFS) == 0x4D42)
   {
@@ -785,10 +788,15 @@ void OXRS_LCD::_drawBmp(const char *filename, int16_t x, int16_t y) {
     _read32(bmpFS);
     w = _read32(bmpFS);
     h = _read32(bmpFS);
+    if ((w != 40) || (h != 40))
+    {
+      Serial.println(F("[lcd] logo size not 40x40"));
+    }
 
     if ((_read16(bmpFS) == 1) && (_read16(bmpFS) == 24) && (_read32(bmpFS) == 0))
     {
-      y += h - 1;
+      // crop to h = 40
+      y += 40 - 1;
 
       bool oldSwapBytes = tft.getSwapBytes();
       tft.setSwapBytes(true);
@@ -797,7 +805,8 @@ void OXRS_LCD::_drawBmp(const char *filename, int16_t x, int16_t y) {
       uint16_t padding = (4 - ((w * 3) & 3)) & 3;
       uint8_t lineBuffer[w * 3 + padding];
 
-      for (row = 0; row < h; row++) {
+      for (row = 0; row < h; row++)
+      {
         
         bmpFS.read(lineBuffer, sizeof(lineBuffer));
         uint8_t*  bptr = lineBuffer;
@@ -813,13 +822,12 @@ void OXRS_LCD::_drawBmp(const char *filename, int16_t x, int16_t y) {
 
         // Push the pixel row to screen, pushImage will crop the line if needed
         // y is decremented as the BMP image is drawn bottom up
-        tft.pushImage(x, y--, w, 1, (uint16_t*)lineBuffer);
+        // crop to w = 40
+        tft.pushImage(x, y--, 40, 1, (uint16_t*)lineBuffer);
       }
       tft.setSwapBytes(oldSwapBytes);
-      Serial.print("Loaded in "); Serial.print(millis() - startTime);
-      Serial.println(" ms");
     }
-    else Serial.println("BMP format not recognized.");
+    else Serial.println(F("[lcd] BMP format not recognized."));
   }
   bmpFS.close();
 }
@@ -828,14 +836,16 @@ void OXRS_LCD::_drawBmp(const char *filename, int16_t x, int16_t y) {
 // BMP data is stored little-endian, Arduino is little-endian too.
 // May need to reverse subscript order if porting elsewhere.
 
-uint16_t OXRS_LCD::_read16(fs::File &f) {
+uint16_t OXRS_LCD::_read16(File &f) 
+{
   uint16_t result;
   ((uint8_t *)&result)[0] = f.read(); // LSB
   ((uint8_t *)&result)[1] = f.read(); // MSB
   return result;
 }
 
-uint32_t OXRS_LCD::_read32(fs::File &f) {
+uint32_t OXRS_LCD::_read32(File &f) 
+{
   uint32_t result;
   ((uint8_t *)&result)[0] = f.read(); // LSB
   ((uint8_t *)&result)[1] = f.read();

--- a/src/OXRS_LCD.h
+++ b/src/OXRS_LCD.h
@@ -8,7 +8,7 @@
 #include "roboto_fonts.h"
 #include <Ethernet.h>
 #include <WiFi.h>
-#include <FS.h>
+#include <SPIFFS.h>
 
 #define TYPE_FRAME 0
 #define TYPE_STATE 1
@@ -47,6 +47,7 @@ class OXRS_LCD
     void loop(void);
     void trigger_mqtt_rx_led (void);
     void trigger_mqtt_tx_led (void);
+    void show_mqtt_not_connected (void);
 
     
   private:  
@@ -86,12 +87,12 @@ class OXRS_LCD
     void _update_io_48(uint8_t type, uint8_t index, int active);
     void _clear_event(void);
     void _set_backlight(int val);
-    void _set_mqtt_rx_led(int active);
-    void _set_mqtt_tx_led(int active);
+    void _set_mqtt_rx_led(int state);
+    void _set_mqtt_tx_led(int state);
     void _set_ip_link_led(int active);
     void _drawBmp(const char *filename, int16_t x, int16_t y);
-    uint16_t _read16(fs::File &f);
-    uint32_t _read32(fs::File &f);   
+    uint16_t _read16(File &f);
+    uint32_t _read32(File &f);   
 };
 
 

--- a/src/OXRS_LCD.h
+++ b/src/OXRS_LCD.h
@@ -8,6 +8,7 @@
 #include "roboto_fonts.h"
 #include <Ethernet.h>
 #include <WiFi.h>
+#include <FS.h>
 
 #define TYPE_FRAME 0
 #define TYPE_STATE 1
@@ -88,6 +89,9 @@ class OXRS_LCD
     void _set_mqtt_rx_led(int active);
     void _set_mqtt_tx_led(int active);
     void _set_ip_link_led(int active);
+    void _drawBmp(const char *filename, int16_t x, int16_t y);
+    uint16_t _read16(fs::File &f);
+    uint32_t _read32(fs::File &f);   
 };
 
 


### PR DESCRIPTION
This is an updated version of the former PR that also addreses issues #10 and issue #11 .
It also provides an api to show a disconnected mqtt (both leds red)  `show_mqtt_not_connected (void)` The leds return to "normal" behavior with the next trigger_rx / trigger_tx which may be sent explicitly after the mqtt connection has reestablished or just wait for the next transmit / receive.