### PR TITLE
Fix crash with long mqtt topic

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-IO-LCD-ESP32-LIB
-version=1.2.2
+version=1.2.3
 author=OXRS Core Team
 maintainer=moinmoin-sh <moinmoin-sh@t-online.de>
 sentence=ESP32 LCD library for Open eXtensible Rack System projects

--- a/src/OXRS_LCD.cpp
+++ b/src/OXRS_LCD.cpp
@@ -578,7 +578,8 @@ void OXRS_LCD::_show_MQTT_topic(const char * topic)
   tft.setFreeFont(&Roboto_Mono_Thin_13);
 
   char buffer[30];
-  sprintf(buffer, "MQTT: %s", topic);
+  strcpy(buffer, "MQTT: ");
+  strncat(buffer, topic, sizeof(buffer)-strlen(buffer)-1);
   tft.drawString(buffer, 12, 80);
 }
 


### PR DESCRIPTION
fixed FW crashed (reboot) if MQTT topic to display has more than 24 characters