### PR TITLE
New location for network icon

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-IO-LCD-ESP32-LIB
-version=1.2.3
+version=1.2.4
 author=OXRS Core Team
 maintainer=moinmoin-sh <moinmoin-sh@t-online.de>
 sentence=ESP32 LCD library for Open eXtensible Rack System projects

--- a/src/OXRS_LCD.cpp
+++ b/src/OXRS_LCD.cpp
@@ -536,7 +536,7 @@ void OXRS_LCD::_show_MAC(byte mac[])
   tft.setFreeFont(&Roboto_Mono_Thin_13);
 
   char buffer[30];
-  sprintf(buffer, "MAC : %02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  sprintf(buffer, " MAC: %02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
   tft.drawString(buffer, 12, 65);
 }
 

--- a/src/OXRS_LCD.cpp
+++ b/src/OXRS_LCD.cpp
@@ -508,21 +508,21 @@ void OXRS_LCD::_show_IP(IPAddress ip)
   char buffer[30];
   if (ip[0] == 0)
   {
-    sprintf(buffer, "IP  : ---.---.---.---");
+    sprintf(buffer, "  IP: ---.---.---.---");
   }
   else
   {
-    sprintf(buffer, "IP  : %03d.%03d.%03d.%03d", ip[0], ip[1], ip[2], ip[3]);
+    sprintf(buffer, "  IP: %03d.%03d.%03d.%03d", ip[0], ip[1], ip[2], ip[3]);
   }
   tft.drawString(buffer, 12, 50);
   
   if (_wifi)
   {
-    tft.drawBitmap(225, 51, icon_wifi, 11, 10, TFT_BLACK, TFT_WHITE);
+    tft.drawBitmap(13, 51, icon_wifi, 11, 10, TFT_BLACK, TFT_WHITE);
   }
   if (_ethernet)
   {
-    tft.drawBitmap(225, 51, icon_ethernet, 11, 10, TFT_BLACK, TFT_WHITE);
+    tft.drawBitmap(13, 51, icon_ethernet, 11, 10, TFT_BLACK, TFT_WHITE);
   }
 }
 


### PR DESCRIPTION
Network icon (eth/wifi) has moved next to the link status
![IconPos](https://user-images.githubusercontent.com/53935853/148101635-7af4a375-2f57-4f77-a7d1-e62a8195fc94.png)
closes #26 
