### PR TITLE
optional user defined unit for temperature display

### DIFF
--- a/src/OXRS_LCD.cpp
+++ b/src/OXRS_LCD.cpp
@@ -604,7 +604,7 @@ void OXRS_LCD::trigger_mqtt_tx_led(void)
   _last_tx_trigger = millis(); 
 }
 
-void OXRS_LCD::show_temp(float temperature)
+void OXRS_LCD::show_temp(float temperature, char unit)
 {
   char buffer[30];
   
@@ -612,7 +612,7 @@ void OXRS_LCD::show_temp(float temperature)
   tft.setTextColor(TFT_WHITE);
   tft.setTextDatum(TL_DATUM);
   tft.setFreeFont(&Roboto_Mono_Thin_13);
-  sprintf(buffer, "TEMP: %2.1f C", temperature);
+  sprintf(buffer, "TEMP: %2.1f %c", temperature, unit);
   tft.drawString(buffer, 12, 95);
 }
 
@@ -626,7 +626,7 @@ void OXRS_LCD::show_event(const char * s_event)
   tft.setTextColor(TFT_BLACK, TFT_WHITE);
   tft.setTextDatum(TL_DATUM);
   tft.setFreeFont(FMB9);       // Select Free Mono Bold 9
-  tft.drawString(s_event, 10, 225);
+  tft.drawString(s_event, 5, 225);
   tft.setTextColor(TFT_WHITE, TFT_BLACK);
   _last_event_display = millis(); 
 }

--- a/src/OXRS_LCD.h
+++ b/src/OXRS_LCD.h
@@ -110,7 +110,7 @@ class OXRS_LCD
     void trigger_mqtt_rx_led (void);
     void trigger_mqtt_tx_led (void);
     
-    void show_temp (float temperature);
+    void show_temp (float temperature, char unit = 'C');
     void show_event (const char * s_event);
     
     void setBrightnessOn (int brightness_on);


### PR DESCRIPTION
the displayed unit to be displayed can be passed as optional parameter ` OXRS_LCD::show_temp(float temperature, char unit)`
Use a single character, Default (if nothing passed) is 'C',
backward compatible 
closes #19 